### PR TITLE
Bugfix : bad occurence matches because of LIKE % query

### DIFF
--- a/prestashop_seoredirections.php
+++ b/prestashop_seoredirections.php
@@ -22,7 +22,7 @@ class Prestashop_SEORedirections extends Module
     {
         $this->name = 'prestashop_seoredirections';
         $this->tab = 'seo';
-        $this->version = '0.1.0';
+        $this->version = '0.1.2';
         $this->author = 'Novius';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = ['min' => '1.6', 'max' => _PS_VERSION_];
@@ -516,8 +516,8 @@ class Prestashop_SEORedirections extends Module
                 $parsed_url = parse_url($old_url);
                 // Do a new search only if there are GET parameters in previous OLD URL search
                 if (! empty($parsed_url['query'])) {
-                    $old_url = $base_uri.$parsed_url['path'];
-                    $result = RedirectionModel::findRedirectionByOldUrl($old_url, true);
+                    $old_url = $base_uri.$parsed_url['path']; // Search occurrence without query parameter
+                    $result = RedirectionModel::findRedirectionByOldUrl($old_url);
                 }
             }
 


### PR DESCRIPTION
Example : 

If we have in BDD 

| old_url        | new_url           | 
| ------------- |:-------------:|
| www.mywebsite.com/test-old     | www.mywebsite.com/test-new |

Called URL is `www.mywebsite.com?mylogout`

System will searches `LIKE "www.mywebsite.com%"` and redirection will be done because BDD line match : it's a bug.